### PR TITLE
fix: Update Dockerfile to work with cslam#34

### DIFF
--- a/docker/Dockerfile.lidar
+++ b/docker/Dockerfile.lidar
@@ -1,4 +1,4 @@
-FROM ros:humble-perception
+FROM ros:jazzy-perception
 
 RUN apt-get update
 RUN apt-get install python3-pip python3-vcstool -y
@@ -11,14 +11,14 @@ RUN git clone https://github.com/MISTLab/Swarm-SLAM.git &&\
     vcs import src < cslam.repos
 
 RUN cd Swarm-SLAM &&\
-    pip install -r requirements.txt
+    pip install --break-system-packages -r requirements.txt
 
 RUN cd Swarm-SLAM &&\
     rosdep update &&\
     rosdep install --from-paths src --ignore-src -r -y
 
 RUN cd Swarm-SLAM &&\
-    . /opt/ros/humble/setup.sh &&\
+    . /opt/ros/$ROS_DISTRO/setup.sh &&\
     colcon build
 
 RUN git clone https://github.com/MIT-SPARK/TEASER-plusplus.git &&\
@@ -28,9 +28,9 @@ RUN git clone https://github.com/MIT-SPARK/TEASER-plusplus.git &&\
     cmake -DTEASERPP_PYTHON_VERSION=3.10 .. &&\
     make teaserpp_python &&\
     cd python &&\
-    pip install .
+    pip install --break-system-packages .
 
-RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> ~/.bashrc
 RUN echo "source Swarm-SLAM/install/setup.bash" >> ~/.bashrc
 
 ADD https://api.github.com/repos/lajoiepy/cslam/commits?per_page=1 head_cslam


### PR DESCRIPTION
The PR https://github.com/lajoiepy/cslam/pull/34 updates CSLAM to work with ROS 2 Jazzy but this change removes direct compatability with Humble and therefore the Dockerfile that is based on ROS 2 Humble produced the following errors:

```
 => ERROR [ 8/15] RUN cd Swarm-SLAM &&    . /opt/ros/humble/setup.sh &&    colcon build                       87.0s
------
 > [ 8/15] RUN cd Swarm-SLAM &&    . /opt/ros/humble/setup.sh &&    colcon build:
1.233 Starting >>> cslam_common_interfaces
16.32 Finished <<< cslam_common_interfaces [15.1s]
16.33 Starting >>> cslam
85.95 --- stderr: cslam
85.95 CMake Warning (dev) at /usr/share/cmake-3.22/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
85.95   Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
85.95   Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
85.95   command to set the policy and suppress this warning.
85.95
85.95   CMake variable PCL_ROOT is set to:
85.95
85.95     /usr
85.95
85.95   For compatibility, CMake is ignoring the variable.
85.95 Call Stack (most recent call first):
85.95   /opt/ros/humble/lib/x86_64-linux-gnu/rtabmap-0.21/RTABMapConfig.cmake:7 (find_dependency)
85.95   /opt/ros/humble/share/rtabmap_conversions/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
85.95   /opt/ros/humble/share/rtabmap_conversions/cmake/rtabmap_conversionsConfig.cmake:41 (include)
85.95   CMakeLists.txt:54 (find_package)
85.95 This warning is for project developers.  Use -Wno-dev to suppress it.
85.95
85.95 In file included from /Swarm-SLAM/src/cslam/src/front_end/visualization_utils.cpp:1:
85.95 /Swarm-SLAM/src/cslam/include/cslam/front_end/visualization_utils.h:6:10: fatal error: cv_bridge/cv_bridge.hpp: No such file or directory
85.95     6 | #include <cv_bridge/cv_bridge.hpp>
85.95       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
85.95 compilation terminated.
85.95 gmake[2]: *** [CMakeFiles/map_manager.dir/build.make:132: CMakeFiles/map_manager.dir/src/front_end/visualization_utils.cpp.o] Error 1
85.95 gmake[2]: *** Waiting for unfinished jobs....
85.95 In file included from /Swarm-SLAM/src/cslam/src/front_end/rgbd_handler.cpp:1:
85.95 /Swarm-SLAM/src/cslam/include/cslam/front_end/rgbd_handler.h:29:10: fatal error: cv_bridge/cv_bridge.hpp: No such file or directory
85.95    29 | #include <cv_bridge/cv_bridge.hpp>
85.95       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
85.95 compilation terminated.
85.95 In file included from /Swarm-SLAM/src/cslam/include/cslam/front_end/stereo_handler.h:4,
85.95                  from /Swarm-SLAM/src/cslam/include/cslam/front_end/map_manager.h:8,
85.95                  from /Swarm-SLAM/src/cslam/src/front_end/map_manager_node.cpp:1:
85.95 /Swarm-SLAM/src/cslam/include/cslam/front_end/rgbd_handler.h:29:10: fatal error: cv_bridge/cv_bridge.hpp: No such file or directory
85.95    29 | #include <cv_bridge/cv_bridge.hpp>
85.95       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
85.95 compilation terminated.
85.95 In file included from /Swarm-SLAM/src/cslam/include/cslam/front_end/stereo_handler.h:4,
85.95                  from /Swarm-SLAM/src/cslam/include/cslam/front_end/map_manager.h:8,
85.95                  from /Swarm-SLAM/src/cslam/src/front_end/map_manager.cpp:1:
85.95 /Swarm-SLAM/src/cslam/include/cslam/front_end/rgbd_handler.h:29:10: fatal error: cv_bridge/cv_bridge.hpp: No such file or directory
85.95    29 | #include <cv_bridge/cv_bridge.hpp>
85.95       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
85.95 compilation terminated.
85.95 In file included from /Swarm-SLAM/src/cslam/include/cslam/front_end/stereo_handler.h:4,
85.95                  from /Swarm-SLAM/src/cslam/src/front_end/stereo_handler.cpp:1:
85.95 /Swarm-SLAM/src/cslam/include/cslam/front_end/rgbd_handler.h:29:10: fatal error: cv_bridge/cv_bridge.hpp: No such file or directory
85.95    29 | #include <cv_bridge/cv_bridge.hpp>
85.95       |          ^~~~~~~~~~~~~~~~~~~~~~~~~
85.95 compilation terminated.
85.95 gmake[2]: *** [CMakeFiles/map_manager.dir/build.make:118: CMakeFiles/map_manager.dir/src/front_end/rgbd_handler.cpp.o] Error 1
85.95 gmake[2]: *** [CMakeFiles/map_manager.dir/build.make:104: CMakeFiles/map_manager.dir/src/front_end/stereo_handler.cpp.o] Error 1
85.95 gmake[2]: *** [CMakeFiles/map_manager.dir/build.make:90: CMakeFiles/map_manager.dir/src/front_end/map_manager_node.cpp.o] Error 1
85.95 gmake[2]: *** [CMakeFiles/map_manager.dir/build.make:76: CMakeFiles/map_manager.dir/src/front_end/map_manager.cpp.o] Error 1
85.95 gmake[1]: *** [CMakeFiles/Makefile2:142: CMakeFiles/map_manager.dir/all] Error 2
85.95 gmake[1]: *** Waiting for unfinished jobs....
85.95 /Swarm-SLAM/src/cslam/src/back_end/gtsam_utils.cpp: In function ‘geometry_msgs::msg::Pose cslam::gtsam_pose_to_msg(const gtsam::Pose3&)’:
85.95 /Swarm-SLAM/src/cslam/src/back_end/gtsam_utils.cpp:10:45: warning: ‘gtsam::Vector gtsam::Rot3::quaternion() const’ is deprecated [-Wdeprecated-declarations]
85.95    10 |   auto rotation = pose.rotation().quaternion();
85.95       |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
85.95 In file included from /opt/ros/humble/include/gtsam/geometry/Pose3.h:24,
85.95                  from /Swarm-SLAM/src/cslam/include/cslam/back_end/gtsam_utils.h:6,
85.95                  from /Swarm-SLAM/src/cslam/src/back_end/gtsam_utils.cpp:1:
85.95 /opt/ros/humble/include/gtsam/geometry/Rot3.h:526:29: note: declared here
85.95   526 |     Vector GTSAM_DEPRECATED quaternion() const;
85.95       |                             ^~~~~~~~~~
85.95 /Swarm-SLAM/src/cslam/src/back_end/gtsam_utils.cpp: In function ‘geometry_msgs::msg::Transform cslam::gtsam_pose_to_transform_msg(const gtsam::Pose3&)’:
85.95 /Swarm-SLAM/src/cslam/src/back_end/gtsam_utils.cpp:25:45: warning: ‘gtsam::Vector gtsam::Rot3::quaternion() const’ is deprecated [-Wdeprecated-declarations]
85.95    25 |   auto rotation = pose.rotation().quaternion();
85.95       |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
85.95 In file included from /opt/ros/humble/include/gtsam/geometry/Pose3.h:24,
85.95                  from /Swarm-SLAM/src/cslam/include/cslam/back_end/gtsam_utils.h:6,
85.95                  from /Swarm-SLAM/src/cslam/src/back_end/gtsam_utils.cpp:1:
85.95 /opt/ros/humble/include/gtsam/geometry/Rot3.h:526:29: note: declared here
85.95   526 |     Vector GTSAM_DEPRECATED quaternion() const;
85.95       |                             ^~~~~~~~~~
85.95 /Swarm-SLAM/src/cslam/src/back_end/decentralized_pgo.cpp: In member function ‘void cslam::DecentralizedPGO::share_optimized_estimates(const gtsam::Values&)’:
85.95 /Swarm-SLAM/src/cslam/src/back_end/decentralized_pgo.cpp:676:45: warning: ‘gtsam::Values::ConstFiltered<gtsam::Value> gtsam::Values::filter(const std::function<bool(long unsigned int)>&) const’ is deprecated [-Wdeprecated-declarations]
85.95   676 |         gtsam_values_to_msg(estimates.filter(gtsam::LabeledSymbol::LabelTest(
85.95       |                             ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
85.95   677 |             ROBOT_LABEL(included_robots_ids.robots.ids[i]))));
85.95       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
85.95 In file included from /opt/ros/humble/include/gtsam/nonlinear/Values.h:571,
85.95                  from /opt/ros/humble/include/gtsam/nonlinear/NonlinearFactor.h:24,
85.95                  from /opt/ros/humble/include/gtsam/nonlinear/NonlinearFactorGraph.h:25,
85.95                  from /opt/ros/humble/include/gtsam/nonlinear/NonlinearOptimizer.h:21,
85.95                  from /opt/ros/humble/include/gtsam/nonlinear/LevenbergMarquardtOptimizer.h:23,
85.95                  from /opt/ros/humble/include/gtsam/nonlinear/GncParams.h:29,
85.95                  from /opt/ros/humble/include/gtsam/nonlinear/GncOptimizer.h:29,
85.95                  from /Swarm-SLAM/src/cslam/include/cslam/back_end/decentralized_pgo.h:10,
85.95                  from /Swarm-SLAM/src/cslam/src/back_end/decentralized_pgo.cpp:1:
85.95 /opt/ros/humble/include/gtsam/nonlinear/Values-inl.h:264:10: note: declared here
85.95   264 |   inline Values::filter(const std::function<bool(Key)>& filterFcn) const {
85.95       |          ^~~~~~
85.95 gmake: *** [Makefile:146: all] Error 2
85.95 ---
85.95 Failed   <<< cslam [1min 10s, exited with code 2]
85.98 [Processing: cslam]
85.98 [Processing: cslam]
85.98
85.98 Summary: 1 package finished [1min 25s]
85.98   1 package failed: cslam
85.98   1 package had stderr output: cslam
85.98   1 package not processed
------
Dockerfile:20
--------------------
  19 |
  20 | >>> RUN cd Swarm-SLAM &&\
  21 | >>>     . /opt/ros/humble/setup.sh &&\
  22 | >>>     colcon build
  23 |
--------------------
ERROR: failed to solve: process "/bin/sh -c cd Swarm-SLAM &&    . /opt/ros/humble/setup.sh &&    colcon build" did not complete successfully: exit code: 2
```

I support the update to the newest LTS version and therefore updated the Dockerfile accordingly. Still I would prefer to also have a working version of the https://github.com/lajoiepy/cslam repository with Humble. Would you be willing to merge a PR creating a separate humble branch for the clsam repository?